### PR TITLE
STEP4

### DIFF
--- a/go/app/infra.go
+++ b/go/app/infra.go
@@ -13,9 +13,10 @@ import (
 var errImageNotFound = errors.New("image not found")
 
 type Item struct {
-	ID   	 int    `db:"id" json:"-"`
-	Name 	 string `db:"name" json:"name"`
-	Category string `db:"category" json:"category"`
+	ID   	  int    `db:"id" json:"-"`
+	Name 	  string `db:"name" json:"name"`
+	Category  string `db:"category" json:"category"`
+	ImageName string `db:"image_name" json:"image_name"`
 }
 
 // Please run `go generate ./...` to generate the mock implementation
@@ -91,8 +92,11 @@ func (i *itemRepository) List(ctx context.Context) ([]*Item, error) {
 
 // StoreImage stores an image and returns an error if any.
 // This package doesn't have a related interface for simplicity.
+// 画像を保存する処理
 func StoreImage(fileName string, image []byte) error {
 	// STEP 4-4: add an implementation to store an image
-
+	if err := os.WriteFile(fileName, image, 0644); err != nil {
+		return fmt.Errorf("failed to write image file: %w", err)
+	}
 	return nil
 }


### PR DESCRIPTION
# STEP4: 出品APIを作る

1. APIを呼び出す
2. 新しい商品を登録する
3. 商品一覧を取得する
4. 画像を登録する
5. 商品の詳細を返す
6. (Optional) Loggerについて調べる

---

# 問題の解答

## 1. GETとPOSTのリクエストの違い

**GET** と **POST** は、HTTPリクエストメソッドのうちの2つで、目的や動作が異なる。

| **項目** | **GET** | **POST** |
|----------|--------|--------|
| **目的** | データの取得 | データの送信・作成 |
| **使用** | Webページの表示やリソースの取得に使用 | フォームの入力データやファイルなどのデータ送信に使用 |
| **データの送信方法** | URLにデータを含めて送信 | リクエストにデータを含めて送信 |
| **セキュリティ** | URLにデータが見えるので、機密情報には不向き | 秘匿情報送信にも利用。データはボディに含まれるが、暗号化しないと安全ではない |
| **キャッシュ** | ブラウザがキャッシュ可能 | 通常キャッシュ不可 |
| **冪等性** | **あり** (同じリクエストを何度送っても同じ結果) | **なし** (同じリクエストを繰り返すとデータが変わる) |

### **例**
- `GET /items` → 登録されている商品の一覧を取得
- `POST /items` → 新しい商品を追加

---

## 2. `http://127.0.0.1:9000/items` にブラウザでアクセスしても `{"message": "item received: <name>"}` が返ってこない理由

ブラウザで直接 `http://127.0.0.1:9000/items` にアクセスすると、**GETリクエスト** が送信される。しかし、`{"message": "item received: <name>"}` のレスポンスは **POSTリクエスト** に対するものであるため、異なるレスポンスになる。

### **アクセス時のHTTPステータスコード**
- ** **`405 Method Not Allowed`**
  - `GET` ではなく `POST` しか許可されていない場合
  - サーバーがリクエストメソッドを理解しているものの、無効にされており使用することができない。例えば、 API がリソースを DELETE することを禁止できる。 GET および HEAD の 2 つは必須で、無効にすることができず、このエラーコードを返してはいけない。

---

## 3. ハッシュ化とはなにか？

- **任意の長さのデータを固定長の値に変換する処理** のこと。ハッシュ化された値は、元のデータに戻すことができない（不可逆変換）。
- 特定の計算手法に基づいて、元のデータを不規則な文字列に置換する処理を指す。
- 同じ画像ファイルを保存する際、同じハッシュ値が割り振られるため、重複して保存することがなくなる。これによりサーバへの負荷を軽減することができる。

### **ハッシュ関数の特性**
- **一方向性**：元のデータに戻せない
- **衝突耐性**：異なるデータが同じハッシュ値にならない
- **出力の固定長**：入力の長さに関わらず、出力は固定の長さ
- **同一性**：同じ入力は常に同じハッシュ値を生成する

### **用途**

電子署名電子メール、配布ファイル、ビットコイン、ブロックチェーン

---

## 4. SHA-256 以外にどんなハッシュ関数があるか

| **アルゴリズム** | **ビット長** | **用途** |
|----------------|------------|---------|
| **MD5** | 128ビット | 古いハッシュ関数（衝突が発見されており安全でない） |
| **SHA-1** | 160ビット | SSL証明書などで使われていたが、衝突が発見され非推奨 |
| **SHA-256** | 256ビット | 現在広く使われているセキュアなハッシュ関数 |
| **SHA-512** | 512ビット | SHA-256 の強化版（より長いハッシュ値） |
| **BLAKE2** | 可変長 | 高速で安全性が高い |
| **Argon2** | 可変長 | パスワードハッシュに特化 |

---

## 5. Log level（ログレベル）とは？

ログレベル（Log Level）は、システムが出力するログの重要度を示す。

### **ログレベルの推奨事項**

### **本番環境（Production）**
#### 1. **Fatal（致命的）**
- **定義**: システムの異常終了を引き起こす深刻なランタイム問題。即時対応が必要。

#### 2. **Error（エラー）**
- **定義**: 直ちに、または近い将来に対応が必要なランタイム問題。

#### 3. **Warn（警告）**
- **定義**: すぐに影響はないが、繰り返されると問題となる可能性のあるランタイム問題。

#### 4. **Info（情報）**
- **定義**: システムの正常な動作を示すイベント。メトリクスやパフォーマンス指標の記録に使用。

### **非本番環境（Non-Production）**
#### 5. **Debug（デバッグ）**
- **定義**: 他のログレベルでは診断できない問題を調査するための詳細な情報。

#### 6. **Trace（トレース）**
- **定義**: 詳細なトレース情報を提供し、デバッグを支援するために使用。

---

## 6. Webサーバーの本番環境ではどのログレベルまで表示するべきか？

- 本番環境では、**Info以上（Fatal, Error, Warn, Info）**を表示するのが一般的。
- **DebugやTraceは開発・テスト環境でのみ使用**し、不要なログを出力しないようにする。

| **環境** | **表示するログレベル** | **理由** |
|----------|------------------|----------|
| **開発環境（Dev）** | `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` | 詳細なデバッグ情報が必要 |
| **本番環境（Prod）** | `INFO`, `WARNING`, `ERROR`, `CRITICAL` | 過剰なログはシステムのパフォーマンスを下げるため、`DEBUG` は出力しない |

---

## 7. キーワードの理解

### **port（ポート番号）**
ポート番号は、サーバーが特定のサービス（HTTP, FTP, SSHなど）を提供するための識別番号。

| **ポート番号** | **用途** |
|--------------|--------|
| 80 | HTTP |
| 443 | HTTPS |
| 3306 | MySQL |
| 5432 | PostgreSQL |
| 9000 | APIサーバー（カスタム） |

---

### **localhost, 127.0.0.1**
- **localhost** → 自分自身のコンピュータ（ホスト名）
- **127.0.0.1** → 自分自身のIPアドレス（ループバックアドレス）

違いはほぼない。`localhost` は `/etc/hosts` の設定次第で変更可能。

---

### **HTTPリクエストメソッド**
| **メソッド** | **説明** |
|------------|------------|
| **GET** | データを取得 |
| **POST** | データを作成 |
| **PUT** | データを更新 |
| **DELETE** | データを削除 |
| **PATCH** | 部分的な更新 |

---

### **HTTPステータスコード**
| **カテゴリ** | **範囲** | **意味** |
|-------------|---------|---------|
| **1XX** | 100-199 | 情報レスポンス |
| **2XX** | 200-299 | 成功レスポンス |
| **3XX** | 300-399 | リダイレクト |
| **4XX** | 400-499 | クライアントエラー |
| **5XX** | 500-599 | サーバーエラー |
