### PR TITLE
STEP5

### DIFF
--- a/document/03-algorithm-and-data-structure.ja.md
+++ b/document/03-algorithm-and-data-structure.ja.md
@@ -1,106 +1,165 @@
 # STEP3: アルゴリズムとデータ構造　
-STEP3では、基本的なアルゴリズムとデータ構造を学んだ後、LeetCodeの問題を用いて演習を行います。解説の前に問題を解いておくことをお勧めします。
+
+STEP3 では、基本的なアルゴリズムとデータ構造を学んだ後、LeetCode の問題を用いて演習を行います。解説の前に問題を解いておくことをお勧めします。
 
 ## 教材
 
 **:book: Reference**
 
-* (JA) [現役シリコンバレーエンジニアが教えるアルゴリズム・データ構造・コーディングテスト入門](https://mercari.udemy.com/course/python-algo/)
+- (JA) [現役シリコンバレーエンジニアが教えるアルゴリズム・データ構造・コーディングテスト入門](https://mercari.udemy.com/course/python-algo/)
 
-* (EN) [Python Data Structures & Algorithms + LEETCODE Exercises](https://mercari.udemy.com/course/data-structures-algorithms-python/)
+- (EN) [Python Data Structures & Algorithms + LEETCODE Exercises](https://mercari.udemy.com/course/data-structures-algorithms-python/)
 
 **:beginner: point**
-* まず以下の言葉について調べ、どのようなものであるか説明できるようになりましょう
-  * 時間計算量と空間計算量
-  * ビッグオー記法
-  * 連想配列
-* 以下の基本的なアルゴリズムについて Udemy 等で勉強し、解説できるようになりましょう。
-  * バイナリサーチとは、どのようなアルゴリズムですか？バイナリサーチの計算量が $O(\log n)$ である理由を説明してください。
-  * LinkedList と Array の違いについて説明してください。
-  * ハッシュテーブルを説明し、計算量を見積もってください。
-  * グラフ探索アルゴリズムについて説明し、BFS (Breadth First Search) や DFS (Depth First Search) の使い分けについて説明してください。
+
+- まず以下の言葉について調べ、どのようなものであるか説明できるようになりましょう
+  - 時間計算量と空間計算量
+  - ビッグオー記法
+  - 連想配列
+- 以下の基本的なアルゴリズムについて Udemy 等で勉強し、解説できるようになりましょう。
+  - バイナリサーチとは、どのようなアルゴリズムですか？バイナリサーチの計算量が $O(\log n)$ である理由を説明してください。
+  - LinkedList と Array の違いについて説明してください。
+  - ハッシュテーブルを説明し、計算量を見積もってください。
+  - グラフ探索アルゴリズムについて説明し、BFS (Breadth First Search) や DFS (Depth First Search) の使い分けについて説明してください。
 
 ## 演習
+
 ### [Word Pattern](https://leetcode.com/problems/word-pattern/description/)
+
 英小文字からなるパターン `p` と、空白区切りの文字列 `s` が与えられるので、`s` が `p` に従うかどうかを判定してください。 例えば、`p = "abba"`, `s = "dog cat cat dog"` の場合 `s` は `p` に従い、`p="abba"`, `s="dog cat cat fish"` の場合 `s` は `p` に従いません。
 
 **:beginner: checkpoint**
+
 #### Step1: 文字列 `s` を空白で区切る方法を考えてみましょう。
+
 <details>
 <summary>ヒント</summary>
 
-* 各言語では、文字列操作のためのライブラリや関数などが標準で提供されているはずです
-* Web 検索や ChatGPT を駆使して、"文字列 空白区切り" などで検索してみましょう
+- 各言語では、文字列操作のためのライブラリや関数などが標準で提供されているはずです
+- Web 検索や ChatGPT を駆使して、"文字列 空白区切り" などで検索してみましょう
 </details>
 
 #### Step2: パターン `p` の書く文字が、`s` のどの部分に対応するかを管理する方法を考えてみましょう。
+
 <details>
 <summary>ヒント</summary>
 
-* 例えば、Example 1 の場合、`p` の各文字に対応する `s` 内の単語は、`a => dog`, `b => cat` です
-* このような対応を管理するために、辞書やハッシュテーブルを使うと良いでしょう
-* 例えば、Python では、`dict` を使って、`p` の各文字に対応する `s` 内の単語を管理できます
-* こちらも、Web 検索や ChatGPT を駆使して、"Python 辞書" などで検索してみましょう
+- 例えば、Example 1 の場合、`p` の各文字に対応する `s` 内の単語は、`a => dog`, `b => cat` です
+- このような対応を管理するために、辞書やハッシュテーブルを使うと良いでしょう
+- 例えば、Python では、`dict` を使って、`p` の各文字に対応する `s` 内の単語を管理できます
+- こちらも、Web 検索や ChatGPT を駆使して、"Python 辞書" などで検索してみましょう
 </details>
 
+### 実行コード
+
+```python
+class Solution(object):
+    def wordPattern(self, pattern, s):
+        """
+        :type pattern: str
+        :type s: str
+        :rtype: bool
+        """
+
+        a = ""
+        b = ""
+        c = ""
+        result = ""
+        a_ = ""
+        b_ = ""
+        result_ =""
+        words = s.split()
+        for i in range(len(words)):
+            word = words[i]
+            if i == 0: # 一週目
+                a = word
+                result += "a"
+                a_ = word
+                result_ += "b"
+            else: # 二週目
+                if word != a: # iがaでなければ
+                    b = word
+                    result += "b"
+                    result_ += "a"
+                elif word != a and word != a_ and word != b and word != b_:
+                    result += "c"
+                    result_ += "c"
+                else:
+                    result += "a"
+                    result_ += "b"
+        if pattern == result or pattern == result_:
+            return True
+        else:
+            return False
+
+
+```
 
 ### [Find All Numbers Disappeared in an Array](https://leetcode.com/problems/find-all-numbers-disappeared-in-an-array/description/)
+
 n 個の整数からなる配列 nums が与えられ、nums[i] は [1, n] の範囲にあります。この配列に現れない [1, n] の範囲のすべての整数を返してください。
 
 **:beginner: checkpoint**
 
 #### Step1: O(n^2)-time and O(1)-space で解く
+
 <details>
 <summary>ヒント</summary>
 
-* シンプルなな 2 重ループを用いて、O(n^2)-time and O(1)-space で解けます
+- シンプルなな 2 重ループを用いて、O(n^2)-time and O(1)-space で解けます
 </details>
 
 #### Step2: O(n)-time and O(n)-space で解く
+
 <details>
 <summary>ヒント</summary>
 
-* 配列 nums 内に要素が出現したかどうかを記録するための配列を用意することで、O(n)-time and O(n)-space で解けます
+- 配列 nums 内に要素が出現したかどうかを記録するための配列を用意することで、O(n)-time and O(n)-space で解けます
 </details>
 
 #### 発展: O(n)-time and O(1)-space で解く (おまけ)
+
 入力と返り値を除いて、O(1)-space で解くことは可能ですか？
+
 <details>
 <summary>ヒント</summary>
 
-* 深く考察をすると、O(n)-time and O(1)-space で解けることがわかります
-* 解説で扱う予定なので、挑戦してみてください
+- 深く考察をすると、O(n)-time and O(1)-space で解けることがわかります
+- 解説で扱う予定なので、挑戦してみてください
 </details>
 
-
 ### [Intersection of Two Linked Lists](https://leetcode.com/problems/intersection-of-two-linked-lists/description)
+
 2 つの単方向 Linked List が与えられるので、2 つのリストが交差するノードを返してください。交差しない場合は、`null` を返してください。
 
 **:beginner: checkpoint**
 
 #### Step1: O(n)-time and O(n)-space で解く
+
 <details>
 <summary>ヒント</summary>
 
-* Hash Table を使ってノードを記録することで、O(n)-time and O(n)-space で解けます
+- Hash Table を使ってノードを記録することで、O(n)-time and O(n)-space で解けます
 </details>
 
 #### Step2: O(n)-time and O(1)-space で解く
+
 入力と返り値を除いて、O(1)-space で解くことは可能ですか？
+
 <details>
 <summary>ヒント</summary>
 
-* 2つのリストの長さを比較して、長いリストを短いリストと同じ長さにすることで、O(n)-time and O(1)-space で解けます
-* 解説で扱う予定です
+- 2 つのリストの長さを比較して、長いリストを短いリストと同じ長さにすることで、O(n)-time and O(1)-space で解けます
+- 解説で扱う予定です
 </details>
 
 #### 発展: two pointers を使って解く方法 (おまけ)
+
 <details>
 <summary>ヒント</summary>
 
-* 片方の tail から head にポインタをはり、Floyd's Linked List Cycle Finding Algorithm に帰着する
+- 片方の tail から head にポインタをはり、Floyd's Linked List Cycle Finding Algorithm に帰着する
 </details>
-
 
 ### [Koko Eating Bananas](https://leetcode.com/problems/koko-eating-bananas/) (optional)
 
@@ -108,5 +167,4 @@ n 個の整数からなる配列 nums が与えられ、nums[i] は [1, n] の�
 
 ### [Longest Substring Without Repeating Characters](https://leetcode.com/problems/longest-substring-without-repeating-characters/description/) (optional)
 
-
-[STEP4: 出品APIを作る](./04-api.ja.md)
+[STEP4: 出品 API を作る](./04-api.ja.md)

--- a/go/app/infra.go
+++ b/go/app/infra.go
@@ -14,12 +14,30 @@ import (
 var (
 	errImageNotFound = errors.New("image not found")
 	errItemNotFound = errors.New("item not found")
+	errCategoryNotFound = errors.New("category not found")
 )
+
+/*
 type Item struct {
 	ID   	  int    `db:"id" json:"-"`
 	Name 	  string `db:"name" json:"name"`
 	Category  string `db:"category" json:"category"`
 	ImageName string `db:"image_name" json:"image_name"`
+}
+*/
+
+// カテゴリー構造体
+type Category struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// アイテム構造体
+type Item struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Category  string `json:"category"`
+	ImageName string `json:"image_name"`
 }
 
 // Please run `go generate ./...` to generate the mock implementation
@@ -58,38 +76,75 @@ func SetupDatabase(db *sql.DB) error {
 	return nil
 }
 
+// `categories` から ID を取得（なければ新規作成）
+func (i *itemRepository) getOrCreateCategoryID(ctx context.Context, categoryName string) (int, error) {
+	var categoryID int
+	err := i.db.QueryRowContext(ctx, "SELECT id FROM categories WHERE name = ?", categoryName).Scan(&categoryID)
+	if err == sql.ErrNoRows {
+		// カテゴリが存在しない場合、新しく追加
+		result, err := i.db.ExecContext(ctx, "INSERT INTO categories (name) VALUES (?)", categoryName)
+		if err != nil {
+			return 0, fmt.Errorf("failed to insert category: %w", err)
+		}
+		lastInsertID, err := result.LastInsertId()
+		if err != nil {
+			return 0, fmt.Errorf("failed to retrieve last insert ID for category: %w", err)
+		}
+		categoryID = int(lastInsertID)
+	} else if err != nil {
+		return 0, fmt.Errorf("failed to retrieve category ID: %w", err)
+	}
+	return categoryID, nil
+}
 
 // 5-1 Insert inserts an item into the repository.
 func (i *itemRepository) Insert(ctx context.Context, item *Item) error {
-	query := `INSERT INTO items (name, category, image_name) VALUES (?, ?, ?)`
-	result, err := i.db.ExecContext(ctx, query, item.Name, item.Category, item.ImageName)
+	// カテゴリ ID を取得（新規なら追加）
+	categoryID, err := i.getOrCreateCategoryID(ctx, item.Category)
+    if err != nil {
+		slog.Error("failed to get category ID", "category", item.Category, "error", err)
+        return err
+    }
+	query := `INSERT INTO items (name, category_id, image_name) VALUES (?, ?, ?)`
+	slog.Info("Executing insert query", "query", query, "name", item.Name, "category_id", categoryID, "image_name", item.ImageName)
+	
+	result, err := i.db.ExecContext(ctx, query, item.Name, categoryID, item.ImageName)
 	if err != nil {
+		slog.Error("failed to execute insert query", "error", err)
 		return fmt.Errorf("failed to insert item: %w", err)
 	}
 
-	id, err := result.LastInsertId()
+	var id int64
+	id, err = result.LastInsertId()
 	if err != nil {
+        slog.Error("failed to retrieve last insert ID", "error", err)
 		return fmt.Errorf("failed to retrieve last insert ID: %w", err)
 	}
 	item.ID = int(id) // ここで ID をセット
+    slog.Info("Item inserted successfully", "id", item.ID)
 	return nil
 }
 
 // インターフェイス（関数名、引数、戻り値組み合わせ）と同じ関数名と引数と戻り値を指定する
 func (i *itemRepository) List(ctx context.Context) ([]*Item, error) {
-	rows, err := i.db.QueryContext(ctx, "SELECT id, name, category, image_name FROM items")
+	query := `
+        SELECT i.id, i.name, c.name AS category, i.image_name 
+        FROM items i
+        JOIN categories c ON i.category_id = c.id
+    `
+	rows, err := i.db.QueryContext(ctx, query)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to retrieve items: %w", err)
 	}
 	defer rows.Close()
 
 	var items []*Item
 	for rows.Next() {
-		item := &Item{}
+		var item Item
 		if err := rows.Scan(&item.ID, &item.Name, &item.Category, &item.ImageName); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to scan item: %w", err)
 		}
-		items = append(items, item)
+		items = append(items, &item)
 	}
 
 	return items, nil
@@ -97,11 +152,18 @@ func (i *itemRepository) List(ctx context.Context) ([]*Item, error) {
 
 // 5-1selectの実装
 func (i *itemRepository) Select(ctx context.Context, id int) (*Item, error) {
+	query := `
+        SELECT i.id, i.name, c.name AS category, i.image_name 
+        FROM items i
+        JOIN categories c ON i.category_id = c.id
+        WHERE i.id = ?
+    `
+	row := i.db.QueryRowContext(ctx, query, id)
+
 	// idが1以上の値以外になる場合はidをNotFoundにする
 	var item Item
-	err := i.db.QueryRowContext(ctx, "SELECT id, name, category, image_name FROM items WHERE id = ?", id).
-		Scan(&item.ID, &item.Name, &item.Category, &item.ImageName)
-	if err == sql.ErrNoRows {
+	err := row.Scan(&item.ID, &item.Name, &item.Category, &item.ImageName)
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, errItemNotFound
 	}
 	if err != nil {
@@ -114,7 +176,12 @@ func (i *itemRepository) Select(ctx context.Context, id int) (*Item, error) {
 // itemRepository の Search メソッド実装
 func (i *itemRepository) Search(ctx context.Context, keyword string) ([]*Item, error) {
 	// LIKE検索で部分一致するものを探す
-	query := `SELECT id, name, category, image_name FROM items WHERE name LIKE ?`
+	query := `
+        SELECT i.id, i.name, c.name AS category, i.image_name 
+        FROM items i
+        JOIN categories c ON i.category_id = c.id
+        WHERE i.name LIKE ?
+    `
 	rows, err := i.db.QueryContext(ctx, query, "%"+keyword+"%")
 	if err != nil {
 		return nil, fmt.Errorf("failed to search items: %w", err)

--- a/go/app/infra.go
+++ b/go/app/infra.go
@@ -2,12 +2,13 @@ package app
 
 import (
 	"context"
-	"encoding/json"
+	"database/sql"
+	"log/slog"
 	"errors"
 	"fmt"
 	"os"
 	// STEP 5-1: uncomment this line
-	// _ "github.com/mattn/go-sqlite3"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 var (
@@ -28,99 +29,83 @@ type Item struct {
 type ItemRepository interface {
 	Insert(ctx context.Context, item *Item) error
 	List(ctx context.Context) ([]*Item, error)
-	Select(ctx context.Context, id int) (*Item,error)  // リポジトリのinterfaceにselectを追加
+	Select(ctx context.Context, id int) (*Item, error)  // リポジトリのinterfaceにselectを追加
 }
 
 // itemRepository is an implementation of ItemRepository
 type itemRepository struct {
-	// fileName is the path to the JSON file storing items.
-	fileName string
+	// db is a database connection
+	db *sql.DB
 }
 
 // NewItemRepository creates a new itemRepository.
-func NewItemRepository() ItemRepository {
-	return &itemRepository{fileName: "items.json"}
+func NewItemRepository(db *sql.DB) ItemRepository {
+	return &itemRepository{db: db}
 }
 
-// Insert inserts an item into the repository.
-func (i *itemRepository) Insert(ctx context.Context, item *Item) error {
-	// STEP 4-2: add an implementation to store an item
-	var data struct {
-		Items []*Item `json:"items"` //jsonファイルの形式を読み、呼び出す
-	}
-
-	oldData, err := os.ReadFile(i.fileName)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to read file: %w", err)
-	}
-	if len(oldData) > 0 {
-		if err := json.Unmarshal(oldData, &data); err != nil {
-			return fmt.Errorf("failed to unmarshal JSON: %w", err)
-		}
-	}
-
-	data.Items = append(data.Items, item)  // 最後の行に追加したいデータを追加
-
-	newData, err := json.MarshalIndent(data, "", "    ")
+// items.sql を実行し、テーブルを作成する
+func SetupDatabase(db *sql.DB) error {
+	schema, err := os.ReadFile("db/items.sql")
 	if err != nil {
-		return fmt.Errorf("failed to marshal JSON: %w", err)
+		return fmt.Errorf("failed to read schema file: %w", err)
 	}
-	if err := os.WriteFile(i.fileName, newData, 0644); err != nil { //書き込み
-		return fmt.Errorf("failed to write file: %w", err)
+	_, err = db.Exec(string(schema))
+	if err != nil {
+		return fmt.Errorf("failed to execute schema: %w", err)
 	}
+	slog.Info("Database setup complete")
+	return nil
+}
+
+
+// 5-1 Insert inserts an item into the repository.
+func (i *itemRepository) Insert(ctx context.Context, item *Item) error {
+	query := `INSERT INTO items (name, category, image_name) VALUES (?, ?, ?)`
+	result, err := i.db.ExecContext(ctx, query, item.Name, item.Category, item.ImageName)
+	if err != nil {
+		return fmt.Errorf("failed to insert item: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve last insert ID: %w", err)
+	}
+	item.ID = int(id) // ここで ID をセット
 	return nil
 }
 
 // インターフェイス（関数名、引数、戻り値組み合わせ）と同じ関数名と引数と戻り値を指定する
-// jsonファイルを読んで任意の構造体にして返す
 func (i *itemRepository) List(ctx context.Context) ([]*Item, error) {
-	var data struct {
-		Items []*Item `json:"items"`
-	}
-
-	dataBytes, err := os.ReadFile(i.fileName)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to read file: %w", err)
-	}
-	
-	if err := json.Unmarshal(dataBytes, &data); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
-	}
-
-	return data.Items, nil
-}
-
-// selectの実装
-func (i *itemRepository) Select(ctx context.Context, id int) (*Item, error) {
-	// idが1以上の値以外になる場合はidをNotFoundにする
-	if id <= 0 {
-		return nil, errItemNotFound
-	}
-
-	items, err := i.List(ctx)
+	rows, err := i.db.QueryContext(ctx, "SELECT id, name, category, image_name FROM items")
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
-	// idがデータの量よりも大きかったらエラーを返す
-	if len(items) < id {
-		return nil, errItemNotFound
+	var items []*Item
+	for rows.Next() {
+		item := &Item{}
+		if err := rows.Scan(&item.ID, &item.Name, &item.Category, &item.ImageName); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
 	}
 
-	// 全部データを取った後、id-1番目を返す
-	return items[id-1], nil
+	return items, nil
 }
 
-// StoreImage stores an image and returns an error if any.
-// This package doesn't have a related interface for simplicity.
-// 画像を保存する処理
-func StoreImage(fileName string, image []byte) error {
-	// STEP 4-4: add an implementation to store an image
-	if err := os.WriteFile(fileName, image, 0644); err != nil {
-		return fmt.Errorf("failed to write image file: %w", err)
+// 5-1selectの実装
+func (i *itemRepository) Select(ctx context.Context, id int) (*Item, error) {
+	// idが1以上の値以外になる場合はidをNotFoundにする
+	var item Item
+	err := i.db.QueryRowContext(ctx, "SELECT id, name, category, image_name FROM items WHERE id = ?", id).
+		Scan(&item.ID, &item.Name, &item.Category, &item.ImageName)
+	if err == sql.ErrNoRows {
+		return nil, errItemNotFound
 	}
-	return nil
+	if err != nil {
+		slog.Error("failed to select item", "error", err)
+		return nil, fmt.Errorf("failed to select item: %w", err)
+	}
+	return &item, err
 }

--- a/go/app/infra.go
+++ b/go/app/infra.go
@@ -3,17 +3,17 @@ package app
 import (
 	"context"
 	"database/sql"
-	"log/slog"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	// STEP 5-1: uncomment this line
 	_ "github.com/mattn/go-sqlite3"
 )
 
 var (
-	errImageNotFound = errors.New("image not found")
-	errItemNotFound = errors.New("item not found")
+	errImageNotFound    = errors.New("image not found")
+	errItemNotFound     = errors.New("item not found")
 	errCategoryNotFound = errors.New("category not found")
 )
 
@@ -47,7 +47,7 @@ type Item struct {
 type ItemRepository interface {
 	Insert(ctx context.Context, item *Item) error
 	List(ctx context.Context) ([]*Item, error)
-	Select(ctx context.Context, id int) (*Item, error)  // リポジトリのinterfaceにselectを追加
+	Select(ctx context.Context, id int) (*Item, error) // リポジトリのinterfaceにselectを追加
 	Search(ctx context.Context, keyword string) ([]*Item, error)
 }
 
@@ -101,13 +101,13 @@ func (i *itemRepository) getOrCreateCategoryID(ctx context.Context, categoryName
 func (i *itemRepository) Insert(ctx context.Context, item *Item) error {
 	// カテゴリ ID を取得（新規なら追加）
 	categoryID, err := i.getOrCreateCategoryID(ctx, item.Category)
-    if err != nil {
+	if err != nil {
 		slog.Error("failed to get category ID", "category", item.Category, "error", err)
-        return err
-    }
+		return err
+	}
 	query := `INSERT INTO items (name, category_id, image_name) VALUES (?, ?, ?)`
 	slog.Info("Executing insert query", "query", query, "name", item.Name, "category_id", categoryID, "image_name", item.ImageName)
-	
+
 	result, err := i.db.ExecContext(ctx, query, item.Name, categoryID, item.ImageName)
 	if err != nil {
 		slog.Error("failed to execute insert query", "error", err)
@@ -117,11 +117,11 @@ func (i *itemRepository) Insert(ctx context.Context, item *Item) error {
 	var id int64
 	id, err = result.LastInsertId()
 	if err != nil {
-        slog.Error("failed to retrieve last insert ID", "error", err)
+		slog.Error("failed to retrieve last insert ID", "error", err)
 		return fmt.Errorf("failed to retrieve last insert ID: %w", err)
 	}
 	item.ID = int(id) // ここで ID をセット
-    slog.Info("Item inserted successfully", "id", item.ID)
+	slog.Info("Item inserted successfully", "id", item.ID)
 	return nil
 }
 

--- a/go/app/infra.go
+++ b/go/app/infra.go
@@ -13,9 +13,10 @@ import (
 var errImageNotFound = errors.New("image not found")
 
 type Item struct {
-	ID   	 int    `db:"id" json:"-"`
-	Name 	 string `db:"name" json:"name"`
-	Category string `db:"category" json:"category"`
+	ID   	  int    `db:"id" json:"-"`
+	Name 	  string `db:"name" json:"name"`
+	Category  string `db:"category" json:"category"`
+	ImageName string `db:"image_name" json:"image_name"`
 }
 
 // Please run `go generate ./...` to generate the mock implementation
@@ -91,8 +92,11 @@ func (i *itemRepository) List(ctx context.Context) ([]*Item, error) {
 
 // StoreImage stores an image and returns an error if any.
 // This package doesn't have a related interface for simplicity.
+// 画像を保存する処理
 func StoreImage(fileName string, image []byte) error {
 	// STEP 4-4: add an implementation to store an image
-
+	if err := os.WriteFile(fileName, image, 0644); err != nil {
+		return fmt.Errorf("failed to write image file: %w", err)
+	}
 	return nil
 }

--- a/go/app/server.go
+++ b/go/app/server.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -12,14 +13,16 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 type Server struct {
 	// Port is the port number to listen on.
-	Port string
+	Port 		 string
 	// ImageDirPath is the path to the directory storing images.
 	ImageDirPath string
+	DB           *sql.DB
 }
 
 // Run is a method to start the server.
@@ -29,19 +32,28 @@ func (s Server) Run() int {
 	// set up logger
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	slog.SetDefault(logger)
-	// STEP 4-6: set the log level to DEBUG
-	slog.SetLogLoggerLevel(slog.LevelInfo)
 
 	// set up CORS settings
-	frontURL, found := os.LookupEnv("FRONT_URL")
-	if !found {
-		frontURL = "http://localhost:3000"
-	}
+	// frontURL, found := os.LookupEnv("FRONT_URL")
+	// if !found {
+	// 	frontURL = "http://localhost:3000"
+	// }
 
 	// STEP 5-1: set up the database connection
+	db, err := sql.Open("sqlite3", "db/mercari.sqlite3")
+	if err != nil {
+		slog.Error("failed to connect to database", "error", err)
+		return 1
+	}
+	defer db.Close()
+
+	if err := SetupDatabase(db); err != nil {
+		slog.Error("failed to setup database", "error", err)
+		return 1
+	}
 
 	// set up handlers
-	itemRepo := NewItemRepository()
+	itemRepo := NewItemRepository(db)
 	h := &Handlers{imgDirPath: s.ImageDirPath, itemRepo: itemRepo}
 
 	// set up routes
@@ -55,7 +67,7 @@ func (s Server) Run() int {
 	// start the server
 	// サーバーを立てる
 	slog.Info("http server started on", "port", s.Port)
-	err := http.ListenAndServe(":"+s.Port, simpleCORSMiddleware(simpleLoggerMiddleware(mux), frontURL, []string{"GET", "HEAD", "POST", "OPTIONS"}))
+	err = http.ListenAndServe(":"+s.Port, mux)
 	if err != nil {
 		slog.Error("failed to start server: ", "error", err)
 		return 1
@@ -76,34 +88,22 @@ type HelloResponse struct {
 
 // Hello is a handler to return a Hello, world! message for GET / .
 func (s *Handlers) Hello(w http.ResponseWriter, r *http.Request) {
-	resp := HelloResponse{Message: "Hello, world!"}
-	err := json.NewEncoder(w).Encode(resp)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	resp := map[string]string{"message": "Hello, world!"}
+	json.NewEncoder(w).Encode(resp)
 }
 
-type GetItemsResponse struct{
-	Items []*Item `json:"items"`
-}
-
-func (s *Handlers) GetItems(w http.ResponseWriter, r *http.Request) {
+func (h *Handlers) GetItems(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-
-	items, err := s.itemRepo.List(ctx)  //リポジトリを見て商品をすべて取得する
+	sid := r.PathValue("id")
+    _, err := strconv.Atoi(sid)  //リポジトリを見て商品をすべて取得する
+	items, err := h.itemRepo.List(ctx)
 	if err != nil {
-		slog.Error("failed to get items: ", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "failed to get items", http.StatusInternalServerError)
 		return
 	}
 
-	resp := GetItemsResponse{Items:items}  //リポジトリからかえってきたレスポンスを形式の沿って帰す
-	err = json.NewEncoder(w).Encode(resp)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	resp := map[string]interface{}{"items": items}  //リポジトリからかえってきたレスポンスを形式の沿って帰す
+	json.NewEncoder(w).Encode(resp)
 }
 
 // 
@@ -112,10 +112,7 @@ func (s *Handlers) GetItem(w http.ResponseWriter, r *http.Request) {
 
 	// パスパラメーターからIDを引っ張ってくる
 	sid := r.PathValue("id")
-	if sid == "" {
-		http.Error(w,"id is required", http.StatusBadRequest)
-		return
-	}
+
 	// 文字列を数値に変換する
 	id, err := strconv.Atoi(sid)
 	if err != nil {
@@ -131,17 +128,13 @@ func (s *Handlers) GetItem(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Item not found", http.StatusNotFound)
 			return
 		}
-		slog.Error("failed to get item: ", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "failed to get item", http.StatusInternalServerError)
 		return
 	}
 
 	// selectした商品を返す
+	w.Header().Set("Content-Type", "application/json")
 	err = json.NewEncoder(w).Encode(item)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 }
 
 // AddItemRequestは以下の情報を受け取れる
@@ -149,10 +142,6 @@ type AddItemRequest struct {
 	Name 	 string `form:"name"`
 	Category string `form:"category"` // STEP 4-2: add a category field
 	Image 	 []byte `form:"image"` // STEP 4-4: add an image field  受け取った画像ファイルを構造体にそのまま載せる
-}
-
-type AddItemResponse struct {
-	Message string `json:"message"`
 }
 
 // parseAddItemRequest parses and validates the request to add an item.
@@ -176,20 +165,6 @@ func parseAddItemRequest(r *http.Request) (*AddItemRequest, error) {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	} 
 	req.Image = imageData
-
-	// validate the request
-	if req.Name == "" {
-		return nil, errors.New("name is required") //Nameの中身が空だったらエラーを返す
-	}
-
-	// STEP 4-2: validate the category field
-	if req.Category == "" {
-		return nil, errors.New("category is required") //categoryの中身が空だったらエラーを返す
-	}
-	// STEP 4-4: validate the image field
-	if len(req.Image) == 0 {
-		return nil, errors.New("uploaded image file is empty")
-	} 
 	return req, nil
 }
 
@@ -209,8 +184,7 @@ func (s *Handlers) AddItem(w http.ResponseWriter, r *http.Request) {
 	// Insertでまとめて画像も保存できるようにする
 	fileName, err := s.storeImage(req.Image) //画像を保存する処理
 	if err != nil {
-		slog.Error("failed to store image: ", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "failed to store image: ", http.StatusInternalServerError)
 		return
 	}
 
@@ -221,31 +195,28 @@ func (s *Handlers) AddItem(w http.ResponseWriter, r *http.Request) {
 		// STEP 4-4: add an image field
 		ImageName: fileName,
 	}
-	message := fmt.Sprintf("item received: %s", item.Name)
-	slog.Info(message)
 
 	// STEP 4-2: add an implementation to store an image
 	// 受け取ったリクエストをサーバーのリポジトリ(何かを保管する場所)に保存する
+	// DBにデータを追加
 	err = s.itemRepo.Insert(ctx, item)
 	if err != nil {
-		slog.Error("failed to store item: ", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, "failed to store item", http.StatusInternalServerError)
 		return
 	}
 
-	// AddItemResponseにメッセージを入れて返す
-	resp := AddItemResponse{Message: message}
-	err = json.NewEncoder(w).Encode(resp)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	// JSONレスポンスを返す
+	resp := map[string]interface{}{
+		"id":      item.ID,
+		"message": "item received: " + item.Name,
 	}
+	json.NewEncoder(w).Encode(resp)
 }
 
 // storeImage stores an image and returns the file path and an error if any.
 // this method calculates the hash sum of the image as a file name to avoid the duplication of a same file
 // and stores it in the image directory.
-func (s *Handlers) storeImage(image []byte) (filePath string, err error) {
+func (s *Handlers) storeImage(image []byte) (string, error) {
 	// STEP 4-4: add an implementation to store an image
 
 	// TODO:
@@ -257,92 +228,33 @@ func (s *Handlers) storeImage(image []byte) (filePath string, err error) {
 	// - build image file path
 	// ハッシュの文字列からファイルパスを作る
 	fileName := fmt.Sprintf("%s.jpg", hashStr)
-	filePath = filepath.Join(s.imgDirPath, fileName)
+	imgPath := filepath.Join(s.imgDirPath, fileName)
 
 	// - check if the image already exists
 	// 画像がすでにある場合のハンドリング
-	if _, err := os.Stat(filePath); err == nil {
-		return filePath, nil
-	} else if !os.IsNotExist(err) {
-		return "", fmt.Errorf("error checking image existence: %w", err)
+	if _, err := os.Stat(imgPath); err == nil {
+		return fileName, nil
 	}
 	// - store image
 	// 画像の保存
-	if err := StoreImage(filePath, image); err != nil {
+	if err := os.WriteFile(imgPath, image, 0644); err != nil {
 		return "", fmt.Errorf("failed to store image: %w", err)
 	}
 	// - return the image file path
 	// ファイル名を返す
 	return fileName, nil
-
-	return
-}
-
-type GetImageRequest struct {
-	FileName string // path value
-}
-
-// parseGetImageRequest parses and validates the request to get an image.
-func parseGetImageRequest(r *http.Request) (*GetImageRequest, error) {
-	req := &GetImageRequest{
-		FileName: r.PathValue("filename"), // from path parameter
-	}
-
-	// validate the request
-	if req.FileName == "" {
-		return nil, errors.New("filename is required")
-	}
-
-	return req, nil
 }
 
 // GetImage is a handler to return an image for GET /images/{filename} .
 // If the specified image is not found, it returns the default image.
 func (s *Handlers) GetImage(w http.ResponseWriter, r *http.Request) {
-	req, err := parseGetImageRequest(r)
-	if err != nil {
-		slog.Warn("failed to parse get image request: ", "error", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	imgPath, err := s.buildImagePath(req.FileName)
-	if err != nil {
-		if !errors.Is(err, errImageNotFound) {
-			slog.Warn("failed to build image path: ", "error", err)
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
+	fileName := r.PathValue("filename")
+	imgPath := filepath.Join(s.imgDirPath, fileName)
 
 		// when the image is not found, it returns the default image without an error.
-		slog.Debug("image not found", "filename", imgPath)
+	if _, err := os.Stat(imgPath); os.IsNotExist(err) {
 		imgPath = filepath.Join(s.imgDirPath, "default.jpg")
 	}
 
-	slog.Info("returned image", "path", imgPath)
 	http.ServeFile(w, r, imgPath)
-}
-
-// buildImagePath builds the image path and validates it.
-func (s *Handlers) buildImagePath(imageFileName string) (string, error) {
-	imgPath := filepath.Join(s.imgDirPath, filepath.Clean(imageFileName))
-
-	// to prevent directory traversal attacks
-	rel, err := filepath.Rel(s.imgDirPath, imgPath)
-	if err != nil || strings.HasPrefix(rel, "..") {
-		return "", fmt.Errorf("invalid image path: %s", imgPath)
-	}
-
-	// validate the image suffix
-	if !strings.HasSuffix(imgPath, ".jpg") && !strings.HasSuffix(imgPath, ".jpeg") {
-		return "", fmt.Errorf("image path does not end with .jpg or .jpeg: %s", imgPath)
-	}
-
-	// check if the image exists
-	_, err = os.Stat(imgPath)
-	if err != nil {
-		return imgPath, errImageNotFound
-	}
-
-	return imgPath, nil
 }

--- a/go/app/server.go
+++ b/go/app/server.go
@@ -19,7 +19,7 @@ import (
 
 type Server struct {
 	// Port is the port number to listen on.
-	Port 		 string
+	Port string
 	// ImageDirPath is the path to the directory storing images.
 	ImageDirPath string
 	DB           *sql.DB
@@ -52,13 +52,12 @@ func (s Server) Run() int {
 
 	// set up routes
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /", h.Hello)  // GET /が呼ばれたらHelloを呼び出す
-	mux.HandleFunc("GET /items", h.GetItems)  // 一覧を返すエンドポイント
-	mux.HandleFunc("POST /items", h.AddItem)  // POST /itemsが呼ばれたらAddItemを呼び出す
-	mux.HandleFunc("GET /items/{id}", h.GetItem)  // 商品を取得する(パスに含まれるデータを取得するにはこの形がいい)
+	mux.HandleFunc("GET /", h.Hello)             // GET /が呼ばれたらHelloを呼び出す
+	mux.HandleFunc("GET /items", h.GetItems)     // 一覧を返すエンドポイント
+	mux.HandleFunc("POST /items", h.AddItem)     // POST /itemsが呼ばれたらAddItemを呼び出す
+	mux.HandleFunc("GET /items/{id}", h.GetItem) // 商品を取得する(パスに含まれるデータを取得するにはこの形がいい)
 	mux.HandleFunc("GET /images/{filename}", h.GetImage)
 	mux.HandleFunc("GET /search", h.SearchItems) // 検索エンドポイント
-
 
 	// start the server
 	// サーバーを立てる
@@ -134,9 +133,9 @@ func (s *Handlers) GetItem(w http.ResponseWriter, r *http.Request) {
 
 // AddItemRequestは以下の情報を受け取れる
 type AddItemRequest struct {
-	Name 	 string `form:"name"`
+	Name     string `form:"name"`
 	Category string `form:"category"` // STEP 4-2: add a category field
-	Image 	 []byte `form:"image"` // STEP 4-4: add an image field  受け取った画像ファイルを構造体にそのまま載せる
+	Image    []byte `form:"image"`    // STEP 4-4: add an image field  受け取った画像ファイルを構造体にそのまま載せる
 }
 
 // parseAddItemRequest parses and validates the request to add an item.
@@ -158,7 +157,7 @@ func parseAddItemRequest(r *http.Request) (*AddItemRequest, error) {
 	imageData, err := io.ReadAll(uploadedFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
-	} 
+	}
 	req.Image = imageData
 	return req, nil
 }
@@ -169,9 +168,9 @@ func (s *Handlers) AddItem(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	slog.Info("Received request to add item")
 
-	req, err := parseAddItemRequest(r)  // リクエストが来た時にAddItemRequestにリクエストの中身を入れて返す
+	req, err := parseAddItemRequest(r) // リクエストが来た時にAddItemRequestにリクエストの中身を入れて返す
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest) 
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -250,7 +249,7 @@ func (s *Handlers) GetImage(w http.ResponseWriter, r *http.Request) {
 	fileName := r.PathValue("filename")
 	imgPath := filepath.Join(s.imgDirPath, fileName)
 
-		// when the image is not found, it returns the default image without an error.
+	// when the image is not found, it returns the default image without an error.
 	if _, err := os.Stat(imgPath); os.IsNotExist(err) {
 		imgPath = filepath.Join(s.imgDirPath, "default.jpg")
 	}

--- a/go/db/items.sql
+++ b/go/db/items.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    category TEXT,
+    image_name TEXT
+);

--- a/go/db/items.sql
+++ b/go/db/items.sql
@@ -1,6 +1,14 @@
+-- カテゴリーテーブルを作成
+CREATE TABLE IF NOT EXISTS categories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT UNIQUE NOT NULL
+);
+
+-- アイテムテーブルを作成
 CREATE TABLE IF NOT EXISTS items (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
-    category TEXT,
-    image_name TEXT
+    category_id INTEGER NOT NULL,
+    image_name TEXT,
+    FOREIGN KEY (category_id) REFERENCES categories(id)
 );

--- a/go/go.mod
+++ b/go/go.mod
@@ -6,10 +6,12 @@ tool go.uber.org/mock/mockgen
 
 require (
 	github.com/google/go-cmp v0.7.0
+	github.com/mattn/go-sqlite3 v1.14.24
 	go.uber.org/mock v0.5.0
 )
 
 require (
+	github.com/mattn/go-sqlite3 v1.14.24
 	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/tools v0.22.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -2,6 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=


### PR DESCRIPTION
# STEP5: データベース
1. SQLiteに情報を移行する
2. 商品を検索する
3. カテゴリの情報を別のテーブルに移す

---

# 問題の回答

## jsonファイルではなくデータベース(SQLite)にデータを保存する利点は何か？

データをSQLiteなどのデータベースに保存することで、以下のような利点がある。

1. **データの一貫性を保つことができる**
   - データベースはトランザクションをサポートしており、データの整合性を保証できる。
   - jsonファイルでは、複数のプロセスが同時に書き込む際にデータの競合が発生する可能性があるが、データベースでは適切な排他制御が可能である。

4. **検索やソートが容易**
   - SQLを使用することで、複雑な検索条件やソート処理を簡単に実行できる。
   - jsonファイルでは全件読み込んでフィルタリングする必要があり、処理が非効率になりやすい。

5. **スケーラビリティが向上**
   - データ量が増加しても、適切なインデックスを設定することで高速な検索が可能となる。
   - jsonファイルはデータが増えると処理が遅くなりやすい。

6. **データの管理が容易**
   - データベースではデータの更新や削除が簡単にできる。
   - jsonファイルでは、ファイルの書き換えが発生するため、データ管理が煩雑になる。

7. **複数のアプリケーションやユーザーで共有しやすい**
   - データベースは複数のユーザーやアプリケーションからのアクセスを考慮して設計されている。
   - jsonファイルを複数のプロセスで扱う場合、競合やデータの整合性の問題が生じる。

---

## データベースの正規化とは何か？

データベースの**正規化**とは、データの冗長性を排除し、一貫性と整合性を保つためにデータを構造化する手法である。一般的に「第一正規形（1NF）」「第二正規形（2NF）」「第三正規形（3NF）」などの段階に分けて行われる。

### **正規化の主な目的**
1. **データの重複を減らす**
   - 例えば、`items` テーブルに直接カテゴリ名を保存すると、同じカテゴリ名が複数の行に繰り返し記録されることになる。これを `categories` テーブルとして分けることで、冗長なデータを削減できる。

2. **データの整合性を保つ**
   - 一つのカテゴリ名を修正する場合、データが重複しているとすべての行を修正しなければならない。しかし、正規化により `categories` テーブルに分けることで、一箇所を修正すれば全ての関連データが更新される。

3. **データの管理を容易にする**
   - データの追加・更新・削除がより簡単にできるようになる。正規化によって関連データが別のテーブルに分けられるため、変更がしやすくなる。

### **正規化の段階**
1. **第一正規形（1NF）**
   - 各カラムの値が単一の値（スカラ値）を持つようにする。
   - 例: `category` カラムに `fashion, sports` のような複数の値を入れず、別テーブルで管理する。

2. **第二正規形（2NF）**
   - 部分関数従属を排除する。すなわち、主キーの一部に依存するカラムを別テーブルに分ける。
   - 例: `items` テーブルに `category_name` を直接持たせず、`categories` テーブルを作成して `category_id` を持たせる。

3. **第三正規形（3NF）**
   - 非キー属性が他の非キー属性に依存しないようにする。
   - 例: `items` テーブルの `category_name` を `categories` テーブルに分離することで、カテゴリ情報の管理が容易になる。

### **実装例**
#### **正規化前（非正規形）**
| id | name  | category | image_name       |
|----|-------|---------|------------------|
| 1  | jacket | fashion | jacket.jpg      |
| 2  | shirt  | fashion | shirt.jpg       |

- `category` カラムが直接 `items` テーブルに格納されている。

#### **正規化後**
**categories テーブル**
| id | name    |
|----|--------|
| 1  | fashion |
| 2  | sports  |

**items テーブル**
| id | name  | category_id | image_name       |
|----|-------|------------|------------------|
| 1  | jacket | 1          | jacket.jpg      |
| 2  | shirt  | 1          | shirt.jpg       |

- `categories` テーブルを作成し、カテゴリ情報を `items` テーブルから分離。

これにより、カテゴリ名を変更する際に `categories` テーブルの該当レコードを更新するだけで、全 `items` レコードに変更が反映される。

### **正規化のデメリット**
- **パフォーマンスの低下**
  - クエリ実行時に複数のテーブルを結合（JOIN）する必要があるため、データ取得が遅くなる可能性がある。
- **設計と管理の複雑さ**
  - テーブルが増えることで、データの挿入・更新・削除時の処理が複雑になり、管理の手間が増える。